### PR TITLE
카카오 로그인 연동

### DIFF
--- a/esg/build.gradle
+++ b/esg/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'net.nurigo:sdk:4.2.7'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'com.google.code.gson:gson:2.8.9'

--- a/esg/src/main/java/esgback/esg/Config/CustomSecurityConfig.java
+++ b/esg/src/main/java/esgback/esg/Config/CustomSecurityConfig.java
@@ -74,7 +74,7 @@ public class CustomSecurityConfig{
 
         LoginSuccessHandler loginSuccessHandler = new LoginSuccessHandler(jwtUtil);
 
-        SocialLoginSuccessHandler socialLoginSuccessHandler = new SocialLoginSuccessHandler();
+        SocialLoginSuccessHandler socialLoginSuccessHandler = new SocialLoginSuccessHandler(passwordEncoder(), jwtUtil);
 
         loginFilter.setAuthenticationSuccessHandler(loginSuccessHandler);
 

--- a/esg/src/main/java/esgback/esg/Config/CustomSecurityConfig.java
+++ b/esg/src/main/java/esgback/esg/Config/CustomSecurityConfig.java
@@ -5,6 +5,7 @@ import esgback.esg.Security.Filter.AccessTokenCheckFilter;
 import esgback.esg.Security.Filter.RefreshTokenFilter;
 import esgback.esg.Security.CustomUserDetailService;
 import esgback.esg.Security.handler.LoginSuccessHandler;
+import esgback.esg.Security.handler.SocialLoginSuccessHandler;
 import esgback.esg.Util.JWTUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
@@ -73,6 +74,8 @@ public class CustomSecurityConfig{
 
         LoginSuccessHandler loginSuccessHandler = new LoginSuccessHandler(jwtUtil);
 
+        SocialLoginSuccessHandler socialLoginSuccessHandler = new SocialLoginSuccessHandler();
+
         loginFilter.setAuthenticationSuccessHandler(loginSuccessHandler);
 
         http.addFilterBefore(loginFilter, UsernamePasswordAuthenticationFilter.class);
@@ -88,7 +91,9 @@ public class CustomSecurityConfig{
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);//세션 사용 안함
         http.formLogin().disable();//기본적인 formLogin 화면을 출력 안한다
         http.cors();
-        http.oauth2Login().loginPage("/login");
+        http.oauth2Login()
+                .loginPage("/login")
+                .successHandler(socialLoginSuccessHandler);
 
         return http.build();
     }

--- a/esg/src/main/java/esgback/esg/Controller/Member/MemberJoinController.java
+++ b/esg/src/main/java/esgback/esg/Controller/Member/MemberJoinController.java
@@ -3,6 +3,7 @@ package esgback.esg.Controller.Member;
 import esgback.esg.DTO.Code.CodeRequestDto;
 import esgback.esg.DTO.Code.CodeResponseDto;
 import esgback.esg.DTO.Member.MemberJoinDto;
+import esgback.esg.DTO.Member.SocialMemberSetDto;
 import esgback.esg.DTO.Response;
 import esgback.esg.Service.Member.MemberInfoService;
 import esgback.esg.DTO.Member.MemberJoinDto;
@@ -77,6 +78,17 @@ public class MemberJoinController {
             return response.fail(e.getMessage(), HttpStatus.NOT_FOUND);
         }
     }//인증번호 검증
+
+    @PatchMapping("register/social")
+    public ResponseEntity<?> joinSocialMember(@RequestBody SocialMemberSetDto socialMemberSetDto) {
+
+        try {
+            memberJoinService.joinSocialMemberInfo(socialMemberSetDto);
+            return response.success("정보 설정 완료");
+        } catch (IllegalArgumentException e) {
+            return response.fail(e.getMessage(), HttpStatus.NOT_FOUND);
+        }
+    }
 
     @PreAuthorize(value = "hasRole('ROLE_ADMIN')")
     @GetMapping("/auth/hello")

--- a/esg/src/main/java/esgback/esg/DTO/Member/MemberLoadUserDto.java
+++ b/esg/src/main/java/esgback/esg/DTO/Member/MemberLoadUserDto.java
@@ -17,14 +17,12 @@ public class MemberLoadUserDto extends User implements OAuth2User {
     private String id;
     private String pwd;
     private Map<String, Object> props;//소셜 로그인 정보
-    private Boolean isExist;
     private Boolean social;
 
-    public MemberLoadUserDto(String username, String pwd, Boolean isExist, Boolean social, Collection<GrantedAuthority> authorities) {
+    public MemberLoadUserDto(String username, String pwd, Boolean social, Collection<GrantedAuthority> authorities) {
         super(username, pwd, authorities);
         this.id = username;
         this.pwd = pwd;
-        this.isExist = isExist;
         this.social = social;//social 로그인이면서 회원 db에 없으면 계정 새로 파야됨
     }
 

--- a/esg/src/main/java/esgback/esg/DTO/Member/MemberLoadUserDto.java
+++ b/esg/src/main/java/esgback/esg/DTO/Member/MemberLoadUserDto.java
@@ -5,19 +5,36 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
+import java.util.Map;
 
 @Getter
 @Setter
-public class MemberLoadUserDto extends User {
+public class MemberLoadUserDto extends User implements OAuth2User {
 
     private String id;
     private String pwd;
+    private Map<String, Object> props;//소셜 로그인 정보
+    private Boolean isExist;
+    private Boolean social;
 
-    public MemberLoadUserDto(String username, String pwd, Collection<GrantedAuthority> authorities) {
+    public MemberLoadUserDto(String username, String pwd, Boolean isExist, Boolean social, Collection<GrantedAuthority> authorities) {
         super(username, pwd, authorities);
         this.id = username;
         this.pwd = pwd;
+        this.isExist = isExist;
+        this.social = social;//social 로그인이면서 회원 db에 없으면 계정 새로 파야됨
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return this.getProps();
+    }
+
+    @Override
+    public String getName() {
+        return this.id;
     }
 }

--- a/esg/src/main/java/esgback/esg/DTO/Member/SocialMemberSetDto.java
+++ b/esg/src/main/java/esgback/esg/DTO/Member/SocialMemberSetDto.java
@@ -1,0 +1,41 @@
+package esgback.esg.DTO.Member;
+
+import esgback.esg.Domain.Member.Address;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class SocialMemberSetDto {
+
+    @NotEmpty
+    private String memberId;
+
+    @NotEmpty
+    private Address address;
+
+    @NotEmpty
+    private LocalDate birthDate;
+
+    @NotEmpty
+    private String nickname;
+
+    @NotEmpty
+    private String password;
+
+    @NotEmpty
+    private String phoneNumber;
+
+    @Builder
+    public SocialMemberSetDto(Address address, LocalDate birthDate, String nickName, String password, String phoneNumber) {
+        this.address = address;
+        this.birthDate = birthDate;
+        this.nickname = nickName;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/esg/src/main/java/esgback/esg/Security/CustomOAuth2UserService.java
+++ b/esg/src/main/java/esgback/esg/Security/CustomOAuth2UserService.java
@@ -1,0 +1,98 @@
+package esgback.esg.Security;
+
+import esgback.esg.DTO.Member.MemberLoadUserDto;
+import esgback.esg.Domain.Enum.Sex;
+import esgback.esg.Domain.Member.Member;
+import esgback.esg.Domain.Member.Role;
+import esgback.esg.Repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        ClientRegistration clientRegistration = userRequest.getClientRegistration();
+        String clientName = clientRegistration.getClientName(); //소셜 로그인 제공 업체
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        String email = null;
+
+        switch (clientName) {
+
+            case "kakao":
+                email = getKaKaoEmail(attributes);
+                break;
+        }
+
+        MemberLoadUserDto memberLoadUserDto = generateDto(email, attributes);
+
+
+        return memberLoadUserDto;
+    }
+
+    private String getKaKaoEmail(Map<String, Object> attributes) {
+        Object kakao_account = attributes.get("kakao_account");
+
+        LinkedHashMap orderedData = (LinkedHashMap) kakao_account;
+
+        String email = (String) orderedData.get("email");
+
+        return email;
+    }
+
+    private MemberLoadUserDto generateDto(String email, Map<String, Object> attributes) {
+        Object kakao_account = attributes.get("kakao_account");
+
+        LinkedHashMap orderedData = (LinkedHashMap) kakao_account;
+
+        boolean isMember = memberRepository.existsByMemberId(email);
+
+        if (!isMember) {
+            LinkedHashMap<String, String> profile = (LinkedHashMap<String, String>)orderedData.get("profile");
+
+            Sex sex = ((orderedData.get("gender").equals("male")) ? Sex.MAN : Sex.WOMAN);
+            String name = profile.get("nickname");
+
+            Member member = Member.builder()
+                    .memberId(email)
+                    .password("1111")
+                    .name(name)
+                    .role(Role.ROLE_USER)
+                    .sex(sex)
+                    .social(true)
+                    .build();
+
+            memberRepository.save(member);
+
+            MemberLoadUserDto memberLoadUserDto = new MemberLoadUserDto(email, "1111", false, true, Arrays.asList(new SimpleGrantedAuthority(Role.ROLE_USER.name())));
+            memberLoadUserDto.setProps(attributes);
+
+            return memberLoadUserDto;
+        }//소셜 로그인 하면서 우리 서비스에 이메일 없을 때
+        else{
+            Member member = memberRepository.findByMemberId(email).get();
+
+            MemberLoadUserDto memberLoadUserDto = new MemberLoadUserDto(member.getMemberId(), member.getPassword(), true, member.getSocial(), Arrays.asList(new SimpleGrantedAuthority(member.getRole().name())));
+
+            return memberLoadUserDto;
+        }
+
+
+    }
+}

--- a/esg/src/main/java/esgback/esg/Security/CustomOAuth2UserService.java
+++ b/esg/src/main/java/esgback/esg/Security/CustomOAuth2UserService.java
@@ -7,6 +7,7 @@ import esgback.esg.Domain.Member.Role;
 import esgback.esg.Repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -21,6 +22,7 @@ import java.util.*;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -68,10 +70,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             Sex sex = ((orderedData.get("gender").equals("male")) ? Sex.MAN : Sex.WOMAN);
             String name = profile.get("nickname");
+            String encodePassword = passwordEncoder.encode("1111");//처음 소셜 로그인 이용하는 사람의 비번은 1111
 
             Member member = Member.builder()
                     .memberId(email)
-                    .password("1111")
+                    .password(encodePassword)
                     .name(name)
                     .role(Role.ROLE_USER)
                     .sex(sex)
@@ -80,7 +83,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             memberRepository.save(member);
 
-            MemberLoadUserDto memberLoadUserDto = new MemberLoadUserDto(email, "1111", false, true, Arrays.asList(new SimpleGrantedAuthority(Role.ROLE_USER.name())));
+            MemberLoadUserDto memberLoadUserDto = new MemberLoadUserDto(email, encodePassword, member.getSocial(), Arrays.asList(new SimpleGrantedAuthority(Role.ROLE_USER.name())));
             memberLoadUserDto.setProps(attributes);
 
             return memberLoadUserDto;
@@ -88,7 +91,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         else{
             Member member = memberRepository.findByMemberId(email).get();
 
-            MemberLoadUserDto memberLoadUserDto = new MemberLoadUserDto(member.getMemberId(), member.getPassword(), true, member.getSocial(), Arrays.asList(new SimpleGrantedAuthority(member.getRole().name())));
+            MemberLoadUserDto memberLoadUserDto = new MemberLoadUserDto(member.getMemberId(), member.getPassword(), member.getSocial(), Arrays.asList(new SimpleGrantedAuthority(member.getRole().name())));
 
             return memberLoadUserDto;
         }

--- a/esg/src/main/java/esgback/esg/Security/CustomUserDetailService.java
+++ b/esg/src/main/java/esgback/esg/Security/CustomUserDetailService.java
@@ -30,6 +30,8 @@ public class CustomUserDetailService implements UserDetailsService {
         MemberLoadUserDto memberLoadUserDto = new MemberLoadUserDto(
                 member.getMemberId(),
                 member.getPassword(),
+                true,
+                false,
                 List.of(new SimpleGrantedAuthority(member.getRole().name())
                 ));
 

--- a/esg/src/main/java/esgback/esg/Security/CustomUserDetailService.java
+++ b/esg/src/main/java/esgback/esg/Security/CustomUserDetailService.java
@@ -31,7 +31,6 @@ public class CustomUserDetailService implements UserDetailsService {
                 member.getMemberId(),
                 member.getPassword(),
                 true,
-                false,
                 List.of(new SimpleGrantedAuthority(member.getRole().name())
                 ));
 

--- a/esg/src/main/java/esgback/esg/Security/handler/SocialLoginSuccessHandler.java
+++ b/esg/src/main/java/esgback/esg/Security/handler/SocialLoginSuccessHandler.java
@@ -1,0 +1,21 @@
+package esgback.esg.Security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class SocialLoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        System.out.println("success handler: " + authentication.getPrincipal());
+
+    }
+}

--- a/esg/src/main/java/esgback/esg/Security/handler/SocialLoginSuccessHandler.java
+++ b/esg/src/main/java/esgback/esg/Security/handler/SocialLoginSuccessHandler.java
@@ -1,21 +1,54 @@
 package esgback.esg.Security.handler;
 
+import com.google.gson.Gson;
+import esgback.esg.DTO.Member.MemberLoadUserDto;
+import esgback.esg.Util.JWTUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
 import java.io.IOException;
+import java.util.Map;
 
 @RequiredArgsConstructor
 public class SocialLoginSuccessHandler implements AuthenticationSuccessHandler {
 
+    private final PasswordEncoder passwordEncoder;
+    private final JWTUtil jwtUtil;
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
 
-        System.out.println("success handler: " + authentication.getPrincipal());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
+        MemberLoadUserDto memberLoadUserDto = (MemberLoadUserDto) authentication.getPrincipal();
+
+        String changeMsg = null;
+
+        if(memberLoadUserDto.getSocial() && (passwordEncoder.matches("1111", memberLoadUserDto.getPwd()))){
+            changeMsg = "need to change pwd";
+        }
+        else{
+            changeMsg = "no need to change pwd";
+        }
+
+        Map<String, Object> claim = Map.of("id", authentication.getName());
+
+        String accessToken = jwtUtil.generateToken(claim, 1);//유효기간 1일
+        String refreshToken = jwtUtil.generateToken(claim, 30);//유효기간 30일
+
+        Map<String, String> tokenInfo = Map.of("accessToken", accessToken, "refreshToken", refreshToken, "changeMsg", changeMsg);
+
+        Gson gson = new Gson();
+
+        String tokenInfoJson = gson.toJson(tokenInfo);
+
+        response.getWriter().println(tokenInfoJson);
     }
 }

--- a/esg/src/main/java/esgback/esg/Service/Member/MemberJoinService.java
+++ b/esg/src/main/java/esgback/esg/Service/Member/MemberJoinService.java
@@ -1,6 +1,7 @@
 package esgback.esg.Service.Member;
 
 import esgback.esg.DTO.Member.MemberJoinDto;
+import esgback.esg.DTO.Member.SocialMemberSetDto;
 import esgback.esg.Domain.Member.Member;
 import esgback.esg.Repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,13 +10,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Transactional
 @Service
 public class MemberJoinService {
 
     private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
+    private final BCryptPasswordEncoder passwordEncoder;
 
     public Boolean checkIdDuplicate(String email) {// id 중복확인
         boolean check = memberRepository.existsByMemberId(email);
@@ -35,5 +38,28 @@ public class MemberJoinService {
         Member member = Member.createMember(memberJoinDto, encodePassword);
 
         memberRepository.save(member);
+    }
+
+    public void joinSocialMemberInfo(SocialMemberSetDto socialMemberSetDto) {
+        Optional<Member> find = memberRepository.findByMemberId(socialMemberSetDto.getMemberId());
+
+        Member member = find.orElseThrow(() -> new IllegalArgumentException("해당 아이디는 존재하지 않습니다."));
+
+        Member newMember = Member.builder()
+                .id(member.getId())
+                .memberId(member.getMemberId())
+                .password(passwordEncoder.encode(socialMemberSetDto.getPassword()))
+                .name(member.getName())
+                .nickName(socialMemberSetDto.getNickname())
+                .role(member.getRole())
+                .address(socialMemberSetDto.getAddress())
+                .sex(member.getSex())
+                .birthDate(socialMemberSetDto.getBirthDate())
+                .discountPrice(member.getDiscountPrice())
+                .phoneNumber(socialMemberSetDto.getPhoneNumber())
+                .social(member.getSocial())
+                .build();
+
+        memberRepository.save(newMember);
     }
 }

--- a/esg/src/main/resources/application.yml
+++ b/esg/src/main/resources/application.yml
@@ -9,6 +9,25 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: kakao
+            scope: profile_nickname, account_email, birthday, gender
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            client-id: "${KAKAO_REST_KEY}"
+            client-secret: "${KAKAO_CLIENT_SECRET_KEY}"
+            client-authentication-method: POST
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            user-name-attribute: id
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
 
 
   jpa:

--- a/esg/src/main/resources/static/login.html
+++ b/esg/src/main/resources/static/login.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <title>Simple Sidebar - Login</title>
+    <!-- Favicon-->
+    <link rel="icon" type="image/x-icon" th:href="@{/assets/favicon.ico}" />
+    <!-- Core theme CSS (includes Bootstrap)-->
+    <link th:href="@{/css/styles.css}" rel="stylesheet" />
+</head>
+<body class="align-middle" >
+<div class="container-fluid d-flex justify-content-center" style="height: 100vh">
+
+    <div class="card align-self-center">
+        <div class="card-header">
+            LOGIN Page
+        </div>
+        <div class="card-body">
+            <th:block th:if="${param.logout != null}">
+                <h1>Logout........</h1>
+            </th:block>
+
+            <form id="registerForm" action="/member/login" method="post">
+                <div class="input-group mb-3">
+                    <span class="input-group-text">아이디</span>
+                    <input type="text" name="username" class="form-control" placeholder="USER ID">
+                </div>
+                <div class="input-group mb-3">
+                    <span class="input-group-text">패스워드</span>
+                    <input type="text" name="password" class="form-control" placeholder="PASSWORD">
+                </div>
+                <div class="input-group mb-3 ">
+                    <input class="form-check-input" type="checkbox" name="remember-me">
+                    <label class="form-check-label">
+                        자동 로그인
+                    </label>
+                </div>
+                <div class="my-4">
+                    <div class="float-end">
+                        <button type="submit" class="btn btn-primary submitBtn">LOGIN</button>
+                    </div>
+                </div>
+            </form>
+            <a href="http://localhost:8080/oauth2/authorization/kakao">KAKAO</a>
+        </div><!--end card body-->
+    </div><!--end card-->
+</div>
+</body>
+</html>

--- a/esg/src/main/resources/static/refreshTest.html
+++ b/esg/src/main/resources/static/refreshTest.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+<h1>ACCESS TOKEN</h1>
+
+<h3 class="accessOld"></h3>
+
+<h3 class="accessResult"></h3>
+
+<hr/>
+
+<h1>REFRESH TOKEN</h1>
+
+<h3 class="refreshOld"></h3>
+
+<h3 class="refreshResult"></h3>
+
+<button class="btn1">Refresh</button>
+
+<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+<script>
+
+
+  const oldAccessToken = localStorage.getItem("accessToken")
+  const oldRefreshToken = localStorage.getItem("refreshToken")
+
+  document.querySelector(".accessOld").innerHTML = oldAccessToken
+  document.querySelector(".refreshOld").innerHTML = oldRefreshToken
+
+
+
+  document.querySelector(".btn1").addEventListener("click", () => {
+
+
+    axios.post('http://localhost:8080/refreshToken',
+            {accessToken: oldAccessToken, refreshToken: oldRefreshToken})
+            .then(res => {
+              console.log(res.data)
+
+              const newAccessToken = res.data.accessToken
+              const newRefreshToken = res.data.refreshToken
+
+              console.log(oldAccessToken === newAccessToken)
+
+              document.querySelector(".accessResult").innerHTML =
+                      oldAccessToken !== newAccessToken?newAccessToken:'OLD'
+              document.querySelector(".refreshResult").innerHTML =
+                      oldRefreshToken !== newRefreshToken?newRefreshToken:'OLD'
+
+
+            })
+            .catch(error => {
+                      console.error(error)
+                    }
+            )
+
+
+  },false)
+
+
+</script>
+
+</body>
+</html>

--- a/esg/src/main/resources/static/tokenCheckFilterTest.html
+++ b/esg/src/main/resources/static/tokenCheckFilterTest.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>TokenCheckFilter_Test</title>
+</head>
+<body>
+<h1>I Request Data for starting with "api</h1>
+<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+
+<script>
+
+    async function callTest(){
+        const response = await axios.get("http://localhost:8080/auth/hello")
+        return response.data
+    }
+
+    callTest()
+        .then(data => console.log(data))
+        .catch(e => console.log(e));
+
+
+</script>
+
+</body>
+</html>

--- a/esg/src/main/resources/static/tokenLogin.html
+++ b/esg/src/main/resources/static/tokenLogin.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test Page</title>
+</head>
+<body>
+<button id="generateTokenBtn">Generate Token</button>
+
+<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+<script>
+    const generateTokenBtn = document.querySelector('#generateTokenBtn');
+
+    generateTokenBtn.addEventListener('click', () => {
+        const data = { id: 'member01', pwd: '1234' };
+
+        axios.post('http://localhost:8080/login', data)
+            .then(response => {
+                alert('Token generated successfully!');
+
+                let accessToken = response.data.accessToken;
+                let refreshToken = response.data.refreshToken;
+
+                localStorage.setItem("accessToken", accessToken);
+                localStorage.setItem("refreshToken", refreshToken);
+            })
+            .catch(error => {
+                console.error(error);
+                alert('Error generating token');
+            });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 진행 사항
- 카카오 api 연동
- 카카오 로그인을 통해서 최초 회원가입이 된 회원에 대해서 우리 서비스에 필요한 정보를 더 기입할 수 있는 컨트롤러 추가



## 테스트 항목
- html 파일 생성 후 카카오 api 연동
- 포스트맨을 통해서 추가 정보 기입 테스트


## 스크린샷 첨부
<img width="570" alt="스크린샷 2023-04-17 오후 1 57 31" src="https://user-images.githubusercontent.com/87291052/232382420-6d7f757b-ed88-467c-ade5-2342437370cd.png">
1. static - login.html 파일에 접속합니다.

<img width="790" alt="스크린샷 2023-04-17 오후 1 55 34" src="https://user-images.githubusercontent.com/87291052/232382531-667869c4-18d4-4b4d-b754-55fed4532cc0.png">
2. 본인 카카오 계정을 기입합니다.

<img width="751" alt="스크린샷 2023-04-17 오후 1 55 59" src="https://user-images.githubusercontent.com/87291052/232382584-e994c58b-5c87-42ec-9ac9-a7daf88cb578.png">
3. 확인하시면 됩니다.

<img width="1644" alt="스크린샷 2023-04-17 오후 1 56 29" src="https://user-images.githubusercontent.com/87291052/232382620-ccb71bd7-1184-496d-92ee-cf44a34d932b.png">
4. 로그인 성공 이후에 3번 id 유저는 카카오에서 제공하는 정보만 저장됩니다.
(추후에 프론트엔드 단에서 필요한 정보를 기입받는 페이지로 넘겨주시면 됩니다.)

<img width="1249" alt="스크린샷 2023-04-17 오후 1 56 46" src="https://user-images.githubusercontent.com/87291052/232382758-efe2f4a0-0460-4203-a1e3-5e6a8b1e0abe.png">
5. 우리 서비스에 소셜 로그인을 통해 최초 회원가입한 유저를 대상으로 추가 정보를 기입받을 때, 필요한 정보입니다.

<img width="1642" alt="스크린샷 2023-04-17 오후 1 57 01" src="https://user-images.githubusercontent.com/87291052/232382868-52351bc0-ceeb-4651-b7dc-efdb7c7e5584.png">
6. 5번 과정을 거친 후에 3번 id 유저의 db 상태입니다.










