### PR TITLE
비밀번호, 닉네임 변경 로직 바꿈

### DIFF
--- a/esg/src/main/java/esgback/esg/Controller/Member/MemberInfoController.java
+++ b/esg/src/main/java/esgback/esg/Controller/Member/MemberInfoController.java
@@ -46,21 +46,21 @@ public class MemberInfoController {
         }
     }//회원 비밀번호 초기화 가능한지 검증 => 비밀번호 분실 시, 비밀번호 재설정 자체가 따로 필요해 보임
 
-    @PatchMapping("/info/reset/pwd")
-    public ResponseEntity<?> resetMemberPwd(@RequestBody ResetDto resetDto) {
+    @PatchMapping("auth/info/reset/pwd")
+    public ResponseEntity<?> resetMemberPwd(@RequestBody ResetDto resetDto, @RequestHeader("authorization") String authorization) {
         try {
-            memberInfoService.resetPwd(resetDto);
+            memberInfoService.resetPwd(resetDto, authorization);
             return response.success("비밀번호 재설정 완료");
         } catch (IllegalArgumentException e) {
             return response.fail("해당하는 계정이 없습니다.", HttpStatus.NOT_FOUND);
         }
     }//회원 비밀번호 재설정
 
-    @PatchMapping("/info/reset/nickname")
-    public ResponseEntity<?> resetNickname(@RequestBody ResetDto resetDto) {
+    @PatchMapping("auth/info/reset/nickname")
+    public ResponseEntity<?> resetNickname(@RequestBody ResetDto resetDto, @RequestHeader("authorization") String authorization) {
 
         try {
-            memberInfoService.resetNickname(resetDto);
+            memberInfoService.resetNickname(resetDto, authorization);
             return response.success("닉네임 재설정 완료");
         } catch (IllegalArgumentException e) {
             return response.fail(e.getMessage(), HttpStatus.NOT_FOUND);

--- a/esg/src/main/java/esgback/esg/DTO/Code/ResetDto.java
+++ b/esg/src/main/java/esgback/esg/DTO/Code/ResetDto.java
@@ -8,13 +8,11 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ResetDto {
 
-    String id;
     String pwd;
     String nickname;
 
     @Builder
-    public ResetDto(String id, String pwd, String nickname) {
-        this.id = id;
+    public ResetDto(String pwd, String nickname) {
         this.pwd = pwd;
         this.nickname = nickname;
     }

--- a/esg/src/main/java/esgback/esg/Service/Member/MemberInfoService.java
+++ b/esg/src/main/java/esgback/esg/Service/Member/MemberInfoService.java
@@ -71,9 +71,13 @@ public class MemberInfoService {
         }
     }
 
-    public void resetPwd(ResetDto resetDto) {
+    public void resetPwd(ResetDto resetDto, String authorization) {
+        String token = authorization.substring(7);
 
-        Optional<Member> find = memberRepository.findByMemberId(resetDto.getId());
+        Map<String, Object> stringObjectMap = jwtUtil.validateToken(token);
+        String memberId = String.valueOf(stringObjectMap.get("id"));
+
+        Optional<Member> find = memberRepository.findByMemberId(memberId);
 
         Member oldMember = find.orElseThrow(() -> new IllegalArgumentException("해당 아이디는 존재하지 않습니다."));
 
@@ -84,8 +88,13 @@ public class MemberInfoService {
         memberRepository.save(newMember);
     }
 
-    public void resetNickname(ResetDto resetDto) {
-        Optional<Member> find = memberRepository.findByMemberId(resetDto.getId());
+    public void resetNickname(ResetDto resetDto, String authorization) {
+        String token = authorization.substring(7);
+
+        Map<String, Object> stringObjectMap = jwtUtil.validateToken(token);
+        String memberId = String.valueOf(stringObjectMap.get("id"));
+
+        Optional<Member> find = memberRepository.findByMemberId(memberId);
         boolean isNickname = memberRepository.existsByNickName(resetDto.getNickname());
 
         Member oldMember = find.orElseThrow(() -> new IllegalArgumentException("해당 아이디는 존재하지 않습니다."));


### PR DESCRIPTION
## 진행 사항
- 비밀번호 변경, 닉네임 변경 시 로그인 확인 추가
- 비밀번호 변경, 닉네임 변경 시 access token 보내도록 변경



## 테스트 항목
- postman을 통한 api 확인


## 스크린샷 첨부
<img width="1090" alt="스크린샷 2023-04-30 오후 10 35 28" src="https://user-images.githubusercontent.com/87291052/235355765-00b277cd-f163-4a16-8912-f0002523769e.png">

<img width="1114" alt="스크린샷 2023-04-30 오후 10 35 39" src="https://user-images.githubusercontent.com/87291052/235355772-985d9f67-3c0a-4da8-aeac-664facb1f03c.png">
